### PR TITLE
style(ui): align color palette and implement retro flat shadows

### DIFF
--- a/app/src/main/java/org/banana/project/MainActivity.kt
+++ b/app/src/main/java/org/banana/project/MainActivity.kt
@@ -80,6 +80,7 @@ class MainActivity : ComponentActivity() {
                                 .padding(16.dp)
                         ) {
                             RetroHeader(
+                                activeScreen = navigator.lastItem,
                                 onDashboardClick = {
                                     navigator.replaceAll(
                                         DashboardScreen(

--- a/app/src/main/java/org/banana/project/navigation/SaleCreationScreen.kt
+++ b/app/src/main/java/org/banana/project/navigation/SaleCreationScreen.kt
@@ -217,7 +217,7 @@ class SaleCreationScreen() : Screen {
                                 "Total: ${format.format(totalAmount)}",
                                 fontWeight = FontWeight.Bold,
                                 fontSize = 18.sp,
-                                color = MaterialTheme.colorScheme.primary
+                                color = MaterialTheme.colorScheme.onSurface
                             )
                         }
                     }
@@ -230,7 +230,8 @@ class SaleCreationScreen() : Screen {
                                 viewModel.submitSale()
                             },
                             colors = ButtonDefaults.buttonColors(
-                                containerColor = MaterialTheme.colorScheme.primary
+                                containerColor = MaterialTheme.colorScheme.secondary,
+                                contentColor = MaterialTheme.colorScheme.onSecondary
                             )
                         ) {
                             Text("Registrar")
@@ -258,14 +259,15 @@ class SaleCreationScreen() : Screen {
                 enabled = parsedItems.isNotEmpty() && !isSubmitting,
                 shape = RoundedCornerShape(14.dp),
                 colors = ButtonDefaults.buttonColors(
-                    containerColor = MaterialTheme.colorScheme.primary,
+                    containerColor = MaterialTheme.colorScheme.secondary,
+                    contentColor = MaterialTheme.colorScheme.onSecondary,
                     disabledContainerColor = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.12f)
                 )
             ) {
                 if (isSubmitting) {
                     CircularProgressIndicator(
                         modifier = Modifier.size(24.dp),
-                        color = MaterialTheme.colorScheme.onPrimary,
+                        color = MaterialTheme.colorScheme.onSecondary,
                         strokeWidth = 2.dp
                     )
                     Spacer(modifier = Modifier.width(12.dp))

--- a/app/src/main/java/org/banana/project/ui/components/HeaderMenu.kt
+++ b/app/src/main/java/org/banana/project/ui/components/HeaderMenu.kt
@@ -1,57 +1,113 @@
-
 package org.banana.project.ui.components
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.geometry.CornerRadius
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import cafe.adriel.voyager.core.screen.Screen
+import org.banana.project.navigation.CreateProductScreen
+import org.banana.project.navigation.DashboardScreen
+import org.banana.project.navigation.SaleCreationScreen
+import org.banana.project.ui.theme.retroOutline
+import org.banana.project.ui.theme.retroShadow
+
+@Composable
+fun RetroMenuItem(
+    text: String,
+    isActive: Boolean,
+    onClick: () -> Unit
+) {
+    if (isActive) {
+        val shadowColor = MaterialTheme.colorScheme.retroShadow
+        val borderColor = MaterialTheme.colorScheme.retroOutline
+        Box(
+            modifier = Modifier
+                .padding(bottom = 4.dp, end = 4.dp) // Leave spacing for the drawn shadow
+                .drawBehind {
+                    // Draw solid retro drop shadow offset to bottom-right
+                    drawRoundRect(
+                        color = shadowColor,
+                        topLeft = Offset(4.dp.toPx(), 4.dp.toPx()),
+                        size = this.size,
+                        cornerRadius = CornerRadius(12.dp.toPx(), 12.dp.toPx())
+                    )
+                }
+                .background(MaterialTheme.colorScheme.tertiary, shape = RoundedCornerShape(12.dp))
+                .border(2.dp, borderColor, shape = RoundedCornerShape(12.dp))
+                .clickable { onClick() }
+                .padding(horizontal = 24.dp, vertical = 14.dp), // Increased size
+            contentAlignment = Alignment.Center
+        ) {
+            Text(
+                text = text,
+                color = MaterialTheme.colorScheme.onTertiary,
+                fontSize = 18.sp,
+                fontWeight = FontWeight.Black
+            )
+        }
+    } else {
+        Text(
+            modifier = Modifier
+                .padding(vertical = 12.dp, horizontal = 12.dp)
+                .clickable { onClick() },
+            text = text,
+            color = MaterialTheme.colorScheme.onPrimary,
+            fontSize = 18.sp,
+            fontWeight = FontWeight.ExtraBold
+        )
+    }
+}
 
 @Composable
 fun HeaderMenu(
+    activeScreen: Screen?,
     onDashboardClick: () -> Unit,
     onCreateProductClick: () -> Unit,
     onSellCreationClick: () -> Unit
 ){
+    val isSellActive = activeScreen is SaleCreationScreen
+    val isProductsActive = activeScreen is CreateProductScreen
+    val isDashboardActive = activeScreen is DashboardScreen
+
     Row(
         modifier = Modifier
             .fillMaxWidth() // Make it span the full width
             .padding(2.dp),
-        horizontalArrangement = Arrangement.SpaceEvenly
+        horizontalArrangement = Arrangement.SpaceEvenly,
+        verticalAlignment = Alignment.CenterVertically
     ){
-        Text(
-            modifier = Modifier
-                .padding(10.dp)
-                .clickable { onSellCreationClick() }, // Make it clickable
+        RetroMenuItem(
             text = "Crear Venta",
-            color = MaterialTheme.colorScheme.onPrimary,
-            fontSize = 20.sp,
-            fontWeight = FontWeight.Bold,
+            isActive = isSellActive,
+            onClick = onSellCreationClick
         )
-        Text(
-            modifier = Modifier
-                .padding(10.dp)
-                .clickable { onCreateProductClick() }, // Make it clickable
+        RetroMenuItem(
             text = "Administrar Productos",
-            color = MaterialTheme.colorScheme.onPrimary,
-            fontSize = 20.sp,
-            fontWeight = FontWeight.Bold,
+            isActive = isProductsActive,
+            onClick = onCreateProductClick
         )
-        Text(
-            modifier = Modifier
-                .padding(10.dp)
-                .clickable { onDashboardClick() }, // Make it clickable
+        RetroMenuItem(
             text = "Indicadores",
-            color = MaterialTheme.colorScheme.onPrimary,
-            fontSize = 20.sp,
-            fontWeight = FontWeight.Bold,
+            isActive = isDashboardActive,
+            onClick = onDashboardClick
         )
     }
 }

--- a/app/src/main/java/org/banana/project/ui/components/ParsedResultsTable.kt
+++ b/app/src/main/java/org/banana/project/ui/components/ParsedResultsTable.kt
@@ -253,31 +253,35 @@ fun ParsedResultsTable(
     }
 
     RetroCard(
-        backgroundColor = MaterialTheme.colorScheme.onPrimary,
+        backgroundColor = MaterialTheme.colorScheme.surface,
         modifier = Modifier.fillMaxWidth()
     ) {
-        Column(
-            modifier = Modifier
-                .fillMaxWidth(0.9f)
-                .padding(vertical = 16.dp),
-            horizontalAlignment = Alignment.CenterHorizontally
+        Surface(
+            color = Color.Transparent,
+            contentColor = MaterialTheme.colorScheme.onSurface
         ) {
-            // Table Header
-            Row(
-                modifier = Modifier.fillMaxWidth().padding(bottom = 8.dp),
-                horizontalArrangement = Arrangement.SpaceBetween,
-                verticalAlignment = Alignment.CenterVertically
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth(0.9f)
+                    .padding(vertical = 16.dp),
+                horizontalAlignment = Alignment.CenterHorizontally
             ) {
-                Text(text = "#", fontWeight = FontWeight.Bold, modifier = Modifier.weight(0.1f), textAlign = TextAlign.Center)
-                Text(text = "Cantidad", fontWeight = FontWeight.Bold, modifier = Modifier.weight(0.2f), textAlign = TextAlign.Center)
-                Text(text = "Producto", fontWeight = FontWeight.Bold, modifier = Modifier.weight(0.4f), textAlign = TextAlign.Center)
-                Text(text = "Precio", fontWeight = FontWeight.Bold, modifier = Modifier.weight(0.3f), textAlign = TextAlign.Center)
-            }
-            
-            androidx.compose.material3.HorizontalDivider(
-                color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.3f),
-                thickness = 1.dp
-            )
+                // Table Header
+                Row(
+                    modifier = Modifier.fillMaxWidth().padding(bottom = 8.dp),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Text(text = "#", fontWeight = FontWeight.Bold, modifier = Modifier.weight(0.1f), textAlign = TextAlign.Center)
+                    Text(text = "Cantidad", fontWeight = FontWeight.Bold, modifier = Modifier.weight(0.2f), textAlign = TextAlign.Center)
+                    Text(text = "Producto", fontWeight = FontWeight.Bold, modifier = Modifier.weight(0.4f), textAlign = TextAlign.Center)
+                    Text(text = "Precio", fontWeight = FontWeight.Bold, modifier = Modifier.weight(0.3f), textAlign = TextAlign.Center)
+                }
+                
+                androidx.compose.material3.HorizontalDivider(
+                    color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.3f),
+                    thickness = 1.dp
+                )
 
             LazyColumn(
                 modifier = Modifier.fillMaxWidth()
@@ -369,7 +373,7 @@ fun ParsedResultsTable(
                                 .fillMaxWidth()
                                 .scale(smoothScale)
                                 .background(mergeHighlightColor)
-                                .background(MaterialTheme.colorScheme.onPrimary.copy(
+                                .background(MaterialTheme.colorScheme.surface.copy(
                                     alpha = 1f - highlightAlpha.value
                                 ))
                                 .padding(vertical = 8.dp),
@@ -465,7 +469,7 @@ fun ParsedResultsTable(
                                 fontWeight = FontWeight.ExtraBold,
                                 modifier = Modifier.weight(0.3f),
                                 textAlign = TextAlign.Center,
-                                color = MaterialTheme.colorScheme.primary
+                                color = MaterialTheme.colorScheme.onSurface
                             )
                         }
                     }
@@ -473,6 +477,7 @@ fun ParsedResultsTable(
             }
         }
     }
+}
 }
 
 @Preview(showBackground = true)

--- a/app/src/main/java/org/banana/project/ui/components/RetroCard.kt
+++ b/app/src/main/java/org/banana/project/ui/components/RetroCard.kt
@@ -23,6 +23,12 @@ import androidx.compose.ui.unit.dp
 import org.banana.project.R
 import org.banana.project.ui.theme.BananaProjectTheme
 
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.geometry.CornerRadius
+import androidx.compose.ui.geometry.Offset
+
+import org.banana.project.ui.theme.retroShadow
+
 @Composable
 fun RetroCard(
     modifier: Modifier = Modifier,
@@ -30,10 +36,20 @@ fun RetroCard(
     borderColor: Color = MaterialTheme.colorScheme.tertiary,
     content: @Composable () -> Unit
 ) {
+    val shadowColor = MaterialTheme.colorScheme.retroShadow
     Box(
         modifier = modifier
+            .padding(bottom = 8.dp, end = 8.dp) // padding so shadow isn't clipped
+            .drawBehind {
+                drawRoundRect(
+                    color = shadowColor.copy(alpha = 0.85f),
+                    topLeft = Offset(6.dp.toPx(), 6.dp.toPx()),
+                    size = this.size,
+                    cornerRadius = CornerRadius(24.dp.toPx(), 24.dp.toPx())
+                )
+            }
             .border(
-                width = 8.dp,
+                width = 6.dp, // Match web app's border-6
                 color = borderColor,
                 shape = RoundedCornerShape(24.dp)
             )

--- a/app/src/main/java/org/banana/project/ui/components/RetroHeader.kt
+++ b/app/src/main/java/org/banana/project/ui/components/RetroHeader.kt
@@ -15,8 +15,11 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 
+import cafe.adriel.voyager.core.screen.Screen
+
 @Composable
 fun RetroHeader(
+    activeScreen: Screen?,
     onDashboardClick: () -> Unit,
     onCreateProductClick: () -> Unit,
     onSellCreationClick: () -> Unit
@@ -39,7 +42,7 @@ fun RetroHeader(
                 fontSize = 50.sp,
                 fontWeight = FontWeight.Bold,
             )
-            HeaderMenu(onDashboardClick, onCreateProductClick, onSellCreationClick)
+            HeaderMenu(activeScreen, onDashboardClick, onCreateProductClick, onSellCreationClick)
         }
     }
 }
@@ -47,5 +50,5 @@ fun RetroHeader(
 @Preview
 @Composable
 fun RetroHeaderPreview(){
-    RetroHeader(onDashboardClick = {}, onCreateProductClick = {}, onSellCreationClick = {})
+    RetroHeader(activeScreen = null, onDashboardClick = {}, onCreateProductClick = {}, onSellCreationClick = {})
 }

--- a/app/src/main/java/org/banana/project/ui/theme/Theme.kt
+++ b/app/src/main/java/org/banana/project/ui/theme/Theme.kt
@@ -6,6 +6,7 @@ import androidx.compose.material3.darkColorScheme
 import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
+import androidx.compose.material3.ColorScheme
 
 private val DarkColorScheme = darkColorScheme(
     primary = Color(0xFFBB86FC),
@@ -13,32 +14,42 @@ private val DarkColorScheme = darkColorScheme(
     tertiary = Color(0xFF3700B3)
 )
 
+val ColorScheme.retroShadow: Color
+    get() = if (primary == TechniColors.Crimson) Color.Black else TechniColors.TokyoNightMagenta
+
+val ColorScheme.retroOutline: Color
+    get() = if (primary == TechniColors.Crimson) Color.Black else outline
+
 private val LightColorScheme = lightColorScheme(
     primary = TechniColors.Crimson,
     secondary = TechniColors.Emerald,
-    tertiary = TechniColors.Goldenrod,
-    background = TechniColors.Cream,
+    tertiary = TechniColors.GoldenTitle,
+    background = TechniColors.Emerald,
     surface = TechniColors.Cream,
-    onPrimary = Color.White,
-    onSecondary = Color.White,
-    onTertiary = Color.Black,
-    onBackground = Color.Black,
-    onSurface = Color.Black,
+    onPrimary = TechniColors.Cream,
+    onSecondary = TechniColors.Cream,
+    onTertiary = TechniColors.Crimson,
+    onBackground = TechniColors.Cream,
+    onSurface = TechniColors.Crimson,
+    primaryContainer = TechniColors.LessGolden,
+    onPrimaryContainer = TechniColors.Crimson,
     error = TechniColors.Crimson,
-    outline = TechniColors.Emerald
+    outline = TechniColors.GoldenTitle
 )
 
 private val TokyoNightColorScheme = darkColorScheme(
-    primary = TechniColors.TokyoNightBlue,
+    primary = TechniColors.TokyoNightSurface,
     secondary = TechniColors.TokyoNightCyan,
     tertiary = TechniColors.TokyoNightMagenta,
     background = TechniColors.TokyoNightBg,
     surface = TechniColors.TokyoNightSurface,
-    onPrimary = TechniColors.TokyoNightBg,
+    onPrimary = TechniColors.TokyoNightFg,
     onSecondary = TechniColors.TokyoNightBg,
     onTertiary = TechniColors.TokyoNightBg,
     onBackground = TechniColors.TokyoNightFg,
     onSurface = TechniColors.TokyoNightFg,
+    primaryContainer = TechniColors.TokyoNightBg,
+    onPrimaryContainer = TechniColors.TokyoNightCyan,
     error = TechniColors.TokyoNightRed,
     outline = TechniColors.TokyoNightBlue
 )

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "9.1.1"
+agp = "9.2.1"
 kotlin = "2.3.10"
 coreKtx = "1.17.0"
 junit = "4.13.2"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Tue Sep 23 17:27:11 COT 2025
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
align color palette and implement retro flat shadows for light/dark themes

- Synchronized `LightColorScheme` with the web app's brand colors, mapping `background` to Emerald and container text to Crimson.
- Enhanced `TokyoNightColorScheme` (dark mode) to use dark surface backgrounds (`primary = TokyoNightSurface`) for headers and cards.
- Introduced `retroShadow` and `retroOutline` extensions to `ColorScheme` to dynamically toggle shadows (Black/Neon Magenta) and borders (Black/Neon Blue) between light and dark modes.
- Updated `RetroCard` and active `RetroMenuItem` to render solid flat drop shadows using a dynamic `drawBehind` Canvas modifier to prevent layout clipping.
- Increased the size of active header menu buttons to match the web app's vertical proportions.
- Refactored `ParsedResultsTable` and `SaleCreationScreen` to map action buttons and totals to theme-appropriate tokens (`secondary`/`onSecondary` and `onSurface`), resolving contrast/visibility issues in both modes.
- Wired the current active screen via `navigator.lastItem` in `MainActivity` to dynamically highlight the active tab in the header.